### PR TITLE
communityとuser_detailsのtable追加

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,0 +1,2 @@
+class Community < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
 class User < ApplicationRecord
 validates :account,presence: true,uniqueness: {case_sensitive: false}
+has_many :articles
+has_one :user_detail
+
+has_many :user_communities
+has_many :communities, through: :user_communities
 end

--- a/app/models/user_community.rb
+++ b/app/models/user_community.rb
@@ -1,0 +1,4 @@
+class UserCommunity < ApplicationRecord
+  belongs_to :user
+  belongs_to :community
+end

--- a/app/models/user_detail.rb
+++ b/app/models/user_detail.rb
@@ -1,0 +1,3 @@
+class UserDetail < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20210109093704_create_user_details.rb
+++ b/db/migrate/20210109093704_create_user_details.rb
@@ -1,0 +1,11 @@
+class CreateUserDetails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_details do |t|
+      t.datetime :birthday
+      t.string :phone_number
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210109094843_create_communities.rb
+++ b/db/migrate/20210109094843_create_communities.rb
@@ -1,0 +1,9 @@
+class CreateCommunities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :communities do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210109095154_create_user_communities.rb
+++ b/db/migrate/20210109095154_create_user_communities.rb
@@ -1,0 +1,11 @@
+class CreateUserCommunities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_communities do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :community, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,60 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_01_09_095154) do
+
+  create_table "articles", charset: "utf8", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "communities", charset: "utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_communities", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "community_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["community_id"], name: "index_user_communities_on_community_id"
+    t.index ["user_id"], name: "index_user_communities_on_user_id"
+  end
+
+  create_table "user_details", charset: "utf8", force: :cascade do |t|
+    t.datetime "birthday"
+    t.string "phone_number"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_details_on_user_id"
+  end
+
+  create_table "users", charset: "utf8", force: :cascade do |t|
+    t.string "account"
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "email"
+  end
+
+  add_foreign_key "articles", "users"
+  add_foreign_key "user_communities", "communities"
+  add_foreign_key "user_communities", "users"
+  add_foreign_key "user_details", "users"
+end


### PR DESCRIPTION
■1対1の実装
⚫︎user_detail

class UserDetail < ApplicationRecord
  belongs_to :user
end

⚫︎has_one  　　models/user.rb
class User < ApplicationRecord
validates :account,presence: true,uniqueness: {case_sensitive: false}
has_many :articles
has_one :user_detail 追加⭕️
end

■多対多
has_many,through

class User < ApplicationRecord
validates :account,presence: true,uniqueness: {case_sensitive: false}
has_many :articles
has_one :user_detail 
has_many :user_communities ⭕️追加
has_many :communities, through: :user_communities　⭕️追加
end







