### PR TITLE
usersテーブルが壊れたことが原因でエラーになったが解決

### DIFF
--- a/db/migrate/20210107160312_create_users.rb
+++ b/db/migrate/20210107160312_create_users.rb
@@ -9,4 +9,5 @@ class CreateUsers < ActiveRecord::Migration[6.1]
         end
       end
     end
+
     

--- a/db/migrate/20210130160942_add_user_id_to_articles.rb
+++ b/db/migrate/20210130160942_add_user_id_to_articles.rb
@@ -3,4 +3,3 @@ class AddUserIdToArticles < ActiveRecord::Migration[6.1]
         add_reference :articles, :user, null: false, foreign_key: true
       end
     end
-    


### PR DESCRIPTION
FactoryBot.build(user)
をusersにしていた。
テーブルを壊してエラーがでた。



ouch db/migrate/20210107160312_create_users.rb

class CreateUsers < ActiveRecord::Migration[6.1]
      def change
        create_table :users do |t|
          t.string :name
          t.string :account
          t.string :email
    
          t.timestamps
        end
      end
    end


touch db/migrate/20210130160942_add_user_id_to_articles.rb

class AddUserIdToArticles < ActiveRecord::Migration[6.1]
      def change
        add_reference :articles, :user, null: false, foreign_key: true
      end
    end
